### PR TITLE
Add prepare script to force `npm publish` to include built JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "tsc",
     "lint": "eslint src/**/* && tsc --noEmit",
-    "test": "jest --ci --verbose --forceExit --detectOpenHandles --coverage"
+    "test": "jest --ci --verbose --forceExit --detectOpenHandles --coverage",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The latest release (`1.0.1`) at the time of writing, did not have a `dist`, so importing the library didn't work.

This fixes that so the build is always run during publish. (`prepare` is an npm hook)

✨